### PR TITLE
Added new Local web files copy path option

### DIFF
--- a/interface/json/InternetOptions.json
+++ b/interface/json/InternetOptions.json
@@ -16,6 +16,9 @@
                 },
                 "password": {
                     "type": "password"
+                },
+                "localcopypath": {
+                    "helper": "Enter a path here (e.g. /var/www/html) to copy files to a local web server folder instead of FTP"
                 }
             }
         },

--- a/interface/json/InternetSchema.json
+++ b/interface/json/InternetSchema.json
@@ -36,6 +36,9 @@
                 },
                 "webcamurl": {
                     "title": "Webcam URL"
+                },
+                "localcopypath": {
+                    "title": "Local web files copy path"
                 }
             }
         },


### PR DESCRIPTION
Hi, following my suggestion in the forum, https://cumulus.hosiene.co.uk/viewtopic.php?f=36&t=18265 I've added the option to locally copy the standard web files so they don't need to be added into "Extra web files" all the time.
I've made changes here and in the main repo.